### PR TITLE
Fix version validation

### DIFF
--- a/src/WPMLInstaller/Plugin.php
+++ b/src/WPMLInstaller/Plugin.php
@@ -227,7 +227,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         // \A = start of string, \Z = end of string
         // See: http://stackoverflow.com/a/34994075
-        $major_minor_patch_optional = '/\A\d\.\d(?:\.\d{1,2})?(?:\.\d)?\Z/';
+        $major_minor_patch_optional = '\A\d\.\d{1,2}(?:\.\d{1,2})?(?:\.\d)?\Z';
         if (!preg_match($major_minor_patch_optional, $version)) {
             throw new \UnexpectedValueException(
                 'The version constraint of ' . $packageName .


### PR DESCRIPTION
Change the validation regex to accept double digits for the second digit (i.e. 2.10.1 )