### PR TITLE
Bump to vlucas/phpdotenv v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "wordpress", "composer", "wp", "plugin", "wpml", "env"
   ],
   "require": {
-    "php": ">=5.5",
+    "php": "^7.0",
     "composer-plugin-api": "^1.0",
-    "vlucas/phpdotenv": "^2.2"
+    "vlucas/phpdotenv": "^3.0"
   },
   "require-dev": {
     "composer/composer": "1.0.*"

--- a/src/WPMLInstaller/Plugin.php
+++ b/src/WPMLInstaller/Plugin.php
@@ -288,7 +288,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     protected function loadDotEnv()
     {
         if (file_exists(getcwd().DIRECTORY_SEPARATOR.'.env')) {
-            $dotenv = new Dotenv(getcwd());
+            $dotenv = Dotenv::create(getcwd());
             $dotenv->load();
         }
     }


### PR DESCRIPTION
Small update to phpdotenv 3, as laravel and bedrock are already using it and it breaks the installation of wpml.